### PR TITLE
Apply renderEntity to child entities

### DIFF
--- a/packages/builder-react/src/interpreter.tsx
+++ b/packages/builder-react/src/interpreter.tsx
@@ -189,7 +189,9 @@ export function InterpreterEntity<TBuilder extends Builder>(props: {
             entityId={entityId}
             components={props.components}
             interpreterStore={props.interpreterStore}
-          />
+          >
+            {renderEntity}
+          </InterpreterEntity>
         ))}
       </EntityComponent>
     ),


### PR DESCRIPTION
I need renderEntity to be passed to child entities when using &lt;InterpreterEntities&gt;. This is already done for &lt;BuilderEntities&gt; but is missing here.